### PR TITLE
Adding rss

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -84,7 +84,7 @@ module.exports = {
       options: {
         name: `{ In Scope }`,
         short_name: `{IS}`,
-        start_url: '/',
+        start_url: `/`,
         background_color: `#ffffff`,
         theme_color: `#663399`,
         display: `minimal-ui`,

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -84,11 +84,61 @@ module.exports = {
       options: {
         name: `{ In Scope }`,
         short_name: `{IS}`,
-        start_url: `/`,
+        start_url: '/',
         background_color: `#ffffff`,
         theme_color: `#663399`,
         display: `minimal-ui`,
         icon: `content/assets/gatsby-icon.png`,
+        query: `
+          {
+            site {
+              siteMetadata {
+                title
+                description
+                siteUrl
+                site_url: siteUrl
+              }
+            }
+          }
+          `,
+        feeds: [
+          {
+            serialize: ({ query: { site, allMarkdownRemark } }) => {
+              return allMarkdownRemark.edges.map(edge => {
+                return Object.assign({}, edge.node.frontmatter, {
+                  description: edge.node.excerpt,
+                  date: edge.node.frontmatter.date,
+                  url: site.siteMetadata.siteUrl + edge.node.fields.slug,
+                  guid: site.siteMetadata.siteUrl + edge.node.fields.slug,
+                  custom_elements: [{ "content:encoded": edge.node.html }],
+                })
+              })
+            },
+            query: `
+              {
+                allMarkdownRemark(
+                  limit: 1000,
+                  sort: { order: DESC, fields: [frontmatter___date] },
+                  filter: {frontmatter: { draft: { ne: true } }}
+                ) {
+                  edges {
+                    node {
+                      excerpt
+                      html
+                      fields { slug }
+                      frontmatter {
+                        title
+                        date
+                      }
+                    }
+                  }
+                }
+              }
+            `,
+            output: "/rss.xml",
+            title: "In Scope RSS Feed",
+          },
+        ],
       },
     },
     `gatsby-plugin-offline`,


### PR DESCRIPTION
By modifying the `gatsby-config.js` file, I now have access to an RSS feed. 

Configuration settings are the default recommended by Gatsby for the [feed plugin](https://www.gatsbyjs.org/packages/gatsby-plugin-feed/).