### PR TITLE
Fix/getblurb missing react

### DIFF
--- a/content/blog/2019-02-06/reasons-to-share.md
+++ b/content/blog/2019-02-06/reasons-to-share.md
@@ -20,7 +20,7 @@ Don’t I know it.
 
 Still, I happily write about the basics and I do so for a few reasons, most notably:
 
-1. Basics do not imply that everyone understands it. Take my recent post about [`.preventDefault()`](../../2019-01-04/20190104-better-form-submissions-with-event-preventdefault-and-htmlformelement-reset/). I didn’t even know it was an option until I came across an instance where I wanted to stop my forms from reloading the page on submission. Now I do. Writing it down a) reinforced the lesson and b) meant that I now have a reference to it (that’s, hopefully, more polished than my notes).
+1. Basics do not imply that everyone understands it. Take my recent post about [`.preventDefault()`](../../2019-01-04/better-form-submissions-with-event-preventdefault-and-htmlformelement-reset/). I didn’t even know it was an option until I came across an instance where I wanted to stop my forms from reloading the page on submission. Now I do. Writing it down a) reinforced the lesson and b) meant that I now have a reference to it (that’s, hopefully, more polished than my notes).
 2. It’s _amazing_ how quickly we forget what we used to not know. Once you learn how to ride a bicycle, you don’t really _think_ about it. You just do it. If you can’t recall what it was like to _not_ know, then it’s pretty hard to teach. After all, you wouldn’t even know _what_ to teach!
 
 I’ve also been having a lot of conversations with new folks - a by-product of that’s what coffee chats and interviewing will do!). That’s given me an opportunity to talk about things that I like and has shown that not everyone spends as much time reading about / experimenting with productivity enhancements as I do.

--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -41,7 +41,7 @@ function Search(props) {
       {results.length > 0 && (
         <SearchContainer>
           {results.map(page => {
-            const blurb = getBlurb(page)
+            const blurb = getBlurb({content: page.content, path: page.path })
             return <SearchResult page={page} blurb={blurb} />
           })}
         </SearchContainer>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -7,6 +7,7 @@ import SEO from '../components/SEO'
 import Header from '../components/Header'
 import PostLink from '../components/PostLink'
 import sortPosts from '../utils/sortPosts'
+import getBlurb from '../utils/getBlurb'
 
 
 class BlogIndex extends React.Component {
@@ -28,9 +29,7 @@ class BlogIndex extends React.Component {
             <div key={slug}>
               <PostLink slug={slug} title={title} />
               <small>{publish ? publish : date}</small>
-              <p dangerouslySetInnerHTML={{ __html: node.excerpt }} />
-              <br />
-              <Link to={`/${slug}`}>&#10149;{`Read more`}</Link>
+              {getBlurb({content: node.excerpt, path: slug})}
             </div>
           )
         })}

--- a/src/utils/getBlurb.js
+++ b/src/utils/getBlurb.js
@@ -1,11 +1,11 @@
+import React from 'react'
 import { Link } from 'gatsby'
 
-export default function getBlurb(page) {
+export default function getBlurb({content, path}) {
   return (
-    <p>
-      {page.content.slice(0, 200)}
-      <br />
-      <Link to={`/${page.path}`}>&#10149;{`Read more`}</Link>
-    </p>
+    <React.Fragment>
+      <p>{content.length > 200 ? content.slice(0, 200).concat(' ...') : content}</p>
+      <Link to={`/${path}`}>&#10149;{`Read more`}</Link>
+    </React.Fragment>
   )
 }


### PR DESCRIPTION
In #224 when I extract `getBlurb` I broke the search by not including `react` as a dependency.

This MR fixes that issue and then reuses the `getBlurb` method on the in page's `index` through a slight change to the API which takes advantage of named parameters. 